### PR TITLE
Add functions to show accessible targets for a user and targetgroups …

### DIFF
--- a/passhport_admin/passhport-admin
+++ b/passhport_admin/passhport-admin
@@ -170,7 +170,13 @@ Options:
     --newcomment=<comment>  Set the new comment of the object.
     --newsshkey=<sshkey>    Set the new SSH key of the user.
         """
-        commands = {"list", "search", "show", "create", "edit", "delete"}
+        commands = {
+            "list",
+            "search",
+            "show",
+            "create",
+            "edit",
+            "delete"}
         arguments = {"<name>", "<pattern>", "<sshkey>"}
         options = {
             "--force",

--- a/passhportd/app/models_mod/targetgroup/__init__.py
+++ b/passhportd/app/models_mod/targetgroup/__init__.py
@@ -60,7 +60,7 @@ class Targetgroup(db.Model):
         output.append("All targets: " + " ".join(self.all_targetname_list()))
         output.append("All usergroups: " + " ".join(self.all_usergroupname_list()))
         output.append("All targetgroups: " + " ".join(self.all_targetgroupname_list()))
-        
+
         return "\n".join(output)
 
 
@@ -118,7 +118,7 @@ class Targetgroup(db.Model):
         """Return all users allowed to access the targetgroup"""
         usernames = self.username_list()
 
-        # The only users allowed are those on usergroups. Not in targets or 
+        # The only users allowed are those on usergroups. Not in targets or
         # targetgroups
         for usergroup in self.gmembers:
             if usergroup not in parsed_usergroups:
@@ -178,7 +178,10 @@ class Targetgroup(db.Model):
 
     def all_targetname_list(self, parsed_targetgroups = []):
         """Return a list with all the targets of this targetgroup"""
-        targetnames = self.target_list()
+        targetnames = self.targetname_list()
+        print(self.tgmembers)
+        print("totoetrauiteluidateauidltesruiteitudetépvcevduceiuea")
+        print(self.tgmembers)
 
         for targetgroup in self.tgmembers:
             if targetgroup not in parsed_targetgroups:

--- a/passhportd/app/models_mod/user/__init__.py
+++ b/passhportd/app/models_mod/user/__init__.py
@@ -4,7 +4,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from app import db
+from app import app, db
+from app.models_mod import target
 
 
 class User(db.Model):
@@ -30,6 +31,8 @@ class User(db.Model):
         output.append("Name: {}".format(self.name))
         output.append("SSH key: {}".format(self.sshkey))
         output.append("Comment: {}".format(self.comment))
+        output.append("Accessible target list: " + \
+            " ".join(self.accessible_targetname_list()))
 
         return "\n".join(output)
 
@@ -37,3 +40,18 @@ class User(db.Model):
     def show_name(self):
         """Return a string containing the user's name"""
         return self.name
+
+
+    def accessible_targetname_list(self):
+        """Return target names which are accessible to the user"""
+        targetnames = []
+
+        query = db.session.query(
+            target.Target).order_by(
+            target.Target.name).all()
+
+        for each_target in query:
+            if self.name in each_target.list_all_usernames():
+                targetnames.append(each_target.show_name())
+
+        return targetnames

--- a/passhportd/app/views_mod/user/__init__.py
+++ b/passhportd/app/views_mod/user/__init__.py
@@ -12,7 +12,7 @@ from flask import request
 from sqlalchemy import exc
 from sqlalchemy.orm import sessionmaker
 from app import app, db
-from app.models_mod import user
+from app.models_mod import user, target
 
 
 @app.route("/user/list")
@@ -66,7 +66,7 @@ def user_show(name):
             '" in the database.', 417, \
             {"content-type": "text/plain; charset=utf-8"}
 
-    return unicode(user_data), 200, \
+    return user_data.__repr__(), 200, \
         {"content-type": "text/plain; charset=utf-8"}
 
 


### PR DESCRIPTION
…which contain a target.

Moreover, there is a bug with a print() in a recursive function.

Commands to reproduct the bug:

passhport-admin user create U1 plop
passhport-admin target create T1 plouf
passhport-admin usergroup create UG1
passhport-admin usergroup create UG2
passhport-admin usergroup create UG3
passhport-admin targetgroup create TG1
passhport-admin targetgroup create TG2
passhport-admin targetgroup create TG3
passhport-admin usergroup adduser U1 UG3
passhport-admin usergroup addusergroup UG2 UG1
passhport-admin usergroup addusergroup UG3 UG2
passhport-admin usergroup addusergroup UG1 UG3
passhport-admin targetgroup addtarget T1 TG3
passhport-admin targetgroup addtargetgroup TG2 TG1
passhport-admin targetgroup addtargetgroup TG3 TG2
passhport-admin targetgroup addtargetgroup TG1 TG3
passhport-admin targetgroup addusergroup UG1 TG3