### PR TITLE
Fix variables syntax in targetgroup and usergroup

### DIFF
--- a/passhportd/app/views_mod/targetgroup/targetgroup.py
+++ b/passhportd/app/views_mod/targetgroup/targetgroup.py
@@ -239,7 +239,7 @@ def targetgroup_adduser():
         return utils.response('ERROR: "' + targetgroupname + '" -> ' + \
                               e.message, 409)
 
-    utils.notif("User " + username + " is now in " + targetgroupname + ".", 
+    utils.notif("User " + username + " is now in " + targetgroupname + ".",
                 "[PaSSHport] " + username + " joins " + targetgroupname )
     return utils.response('OK: "' + username + '" added to "' + \
                           targetgroupname + '"', 200)
@@ -286,7 +286,7 @@ def targetgroup_rmuser():
         return utils.response('ERROR: "' + targetgroupname + '" -> ' + \
                               e.message, 409)
 
-    utils.notif("User " + username + " has been removed from " + targetgroupname + ".", 
+    utils.notif("User " + username + " has been removed from " + targetgroupname + ".",
                 "[PaSSHport] " + username + " removed from " + targetgroupname )
     return utils.response('OK: "' + username + '" removed from "' + \
                           targetgroupname + '"', 200)
@@ -326,8 +326,8 @@ def targetgroup_addtarget():
     except exc.SQLAlchemyError as e:
         return utils.response('ERROR: "' + targetgroupname + '" -> ' + \
                               e.message, 409)
- 
-    utils.notif("Users from " + targetgroupname+ " can now access to " + targetame + ".", 
+
+    utils.notif("Users from " + targetgroupname+ " can now access to " + targetname + ".",
                 "[PaSSHport] " + targetname + " access granted to " + targetgroupname )
     return utils.response('OK: "' + targetname + '" added to "' + \
                           targetgroupname + '"', 200)
@@ -375,7 +375,7 @@ def targetgroup_rmtarget():
                               e.message, 409)
 
     utils.notif("Users from " + targetgroupname+ " can not access to " + \
-                                                     targetame + "anymore.",
+                                                     targetname + "anymore.",
                 "[PaSSHport] " + targetname + " removed from " + \
                                                         targetgroupname )
     return utils.response('OK: "' + targetname + '" removed from "' + \
@@ -418,7 +418,7 @@ def targetgroup_addusergroup():
                               e.message, 409)
 
     utils.notif("Users from " + usergroupname + \
-               " can now access to the targets from " + targetgroupame + ".", 
+               " can now access to the targets from " + targetgroupname + ".",
                 "[PaSSHport] " + usergroupname + " added to " + targetgroupname)
     return utils.response('OK: "' + usergroupname + '" added to "' + \
                           targetgroupname + '"', 200)
@@ -466,7 +466,7 @@ def targetgroup_rmusergroup():
                               e.message, 409)
 
     utils.notif("Users from " + usergroupname + \
-               " lost access to the targets from " + targetgroupame + ".", 
+               " lost access to the targets from " + targetgroupname + ".",
                "[PaSSHport] " + usergroupname + " removed from " + \
                                                           targetgroupname)
     return utils.response('OK: "' + usergroupname + '" removed from "' + \
@@ -515,7 +515,7 @@ def targetgroup_addtargetgroup():
                               e.message, 409)
 
     utils.notif("Users from " + subtargetgroupname + \
-               " can access to the targets from " + targetgroupame + ".", 
+               " can access to the targets from " + targetgroupname + ".",
                "[PaSSHport] " + subtargetgroupname + " added to " + \
                                                           targetgroupname)
     return utils.response('OK: "' + subtargetgroupname + '" added to "' + \
@@ -566,7 +566,7 @@ def targetgroup_rmtargetgroup():
                               e.message, 409)
 
     utils.notif("Users from " + subtargetgroupname + \
-               " removed access to " + targetgroupame + ".", 
+               " removed access to " + targetgroupname + ".",
                "[PaSSHport] " + subtargetgroupname + " removed from " + \
                                                           targetgroupname)
     return utils.response('OK: "' + subtargetgroupname + '" removed from "' + \
@@ -587,4 +587,3 @@ def targetgroup_access(name):
                               '" in the database.', 417)
 
     return utils.response(str(data.accessible_target_list(style="names")), 200)
-

--- a/passhportd/app/views_mod/usergroup/usergroup.py
+++ b/passhportd/app/views_mod/usergroup/usergroup.py
@@ -254,8 +254,8 @@ def usergroup_adduser():
         return utils.response('ERROR: "' + usergroupname + '" -> ' + \
                               e.message, 409)
 
-    utils.notif(username + " added to " + usergroupame + ".\n" + \
-            "He can now access to: \n" + usergroupame.accessible_target_list(),
+    utils.notif(username + " added to " + usergroupname + ".\n" + \
+            "He can now access to: \n" + usergroupname.accessible_target_list(),
             "[PaSSHport] " + username + " added to " + usergroupname)
     return utils.response('OK: "' + username + '" added to "' + \
                           usergroupname + '"', 200)
@@ -302,7 +302,7 @@ def usergroup_rmuser():
         return utils.response('ERROR: "' + usergroupname + '" -> ' + \
                               e.message, 409)
 
-    utils.notif(username + " removed from " + usergroupam2Ye + ".",
+    utils.notif(username + " removed from " + usergroupname + ".",
             "[PaSSHport] " + username + " removed from " + usergroupname)
     return utils.response('OK: "' + username + '" removed from "' + \
                           usergroupname + '"', 200)


### PR DESCRIPTION
Hi !

During a test I found some typo in targetgroup.py & usergroup.py in variable name causing the cli to raise error.

Maybe I missed some others typo but for now I already test this changes.

There is also some minor additional spaces removed.

Kind regards.