### PR TITLE
Add the env variable PASSHPORT_TARGET

### DIFF
--- a/docs/installation-and-configuration/make-passhport-more-transparent-for-user.rst
+++ b/docs/installation-and-configuration/make-passhport-more-transparent-for-user.rst
@@ -1,0 +1,33 @@
+Make passhport more transparent for user
+========================================
+
+It is possible to configure passhport in a way that it is pretty transparent for users.
+
+First you need to allow passing a the environment variable PASSHPORT_TARGET to sshd:
+
+.. code-block:: none
+
+  echo "AcceptEnv PASSHPORT_TARGET" >> /etc/ssh/sshd_config
+  systemctl restart ssh
+
+
+Then you can setup a ssh client like this :
+
+.. code-block:: none
+
+  Host myhost
+    User passhport
+    Hostname mybastion
+    SetEnv PASSHPORT_TARGET=myhost
+    SendEnv PASSHPORT_TARGET
+
+And then use ssh normally
+
+  ssh myhost
+
+or in a command line (e.g for automation tools)
+
+.. code-block:: none
+
+  PASSHPORT_TARGET=myhost ssh -o "SendEnv PASSHPORT_TARGET" passhport@mybastion
+

--- a/passhport/passhport
+++ b/passhport/passhport
@@ -362,6 +362,7 @@ if __name__ == '__main__':
         sys.exit("No such user in PaSSHport database.\n" +
                  "tip: it can be a SSL certificate misconfiguration.")
     originalcmd = os.environ.get('SSH_ORIGINAL_COMMAND')
+    passhport_target = os.environ.get('PASSHPORT_TARGET')
     choice = 0
  
     # If the user can't access any target
@@ -372,11 +373,21 @@ if __name__ == '__main__':
     indexed_target_list = build_targets_list(target_list)
 
     # Check if it's interactive ssh or another type of connection:
-    if originalcmd:
+    if originalcmd or passhport_target:
+        # Check if the target if given through the PASSHPORT_TARGET
+        # environment variable
+
+        if originalcmd:
+            targetcmd = originalcmd
+        else:
+            targetcmd = ""
+        if passhport_target:
+            targetcmd = passhport_target + " " + targetcmd
+        
         # In case the SSH_ORIGINAL_COMMAND is set,
         # it should be scp/rsync (according to sshd manpage)
         # After testing, it can be ssh with a direct command too...
-        direct_connection(username, url_passhport, target_list, originalcmd)
+        direct_connection(username, url_passhport, target_list, targetcmd)
 
     else:
         # We handle the interactive ssh connection

--- a/passhport/passhport-connect.sh
+++ b/passhport/passhport-connect.sh
@@ -46,7 +46,7 @@ fi
 
 # Launch PaSSHport with the same user after the connection
 # If it's a direct connection, we don't connect again
-if [ "${KEEPCONNECT}" -eq "1" ] && [ -z "${SSH_ORIGINAL_COMMAND}" ]
+if [ "${KEEPCONNECT}" -eq "1" ] && [ -z "${SSH_ORIGINAL_COMMAND}" ] && [ -z "${PASSHPORT_TARGET}" ]
 then
     exec ${PYTHONBIN} ${PASSHPORTBIN} ${USERNAME} 
 fi


### PR DESCRIPTION
This variable allow to define the target without interfere in the remote
command line :

- it is more flexible for automation tools (no command interference).
  With a syntax like this :

    PASSHPORT_TARGET=myhost ssh -o SendEnv=PASSHPORT_TARGET bastion <cmd>

- it is more transparent for user. You can define ssh client config like this :

    Host myhost
        User passhport
        Hostname bastion
        SendEnv PASSHPORT_TARGET
        SetEnv "PASSHPORT_TARGET=myhost"

and just type

    ssh myhost <cmd>

or define the bastion like this:

    Host bastion
        User passhport
        Hostname bastion
        SendEnv PASSHPORT_TARGET

and use it like this:

    PASSHPORT_TARGET=myhost ssh bastion <cmd>

This pull request make passhport easier to be used with an automation tool like ansible ans is related to #547 