### PR TITLE
Update to look like targetgroup

### DIFF
--- a/passhportd/app/views_mod/usergroup/usergroup.py
+++ b/passhportd/app/views_mod/usergroup/usergroup.py
@@ -195,18 +195,18 @@ def usergroup_delete(name):
 
     # Check if the name exists
     name = urllib.parse.quote(name)
-    query = db.session.query(
-                usergroup.Usergroup).filter(
-                usergroup.Usergroup.name == name)
+    query = db.session.query(usergroup.Usergroup.name)\
+        .filter_by(name=name).first()
 
     if query is None:
         return utils.response('ERROR: No usergroup with the name "' + name + \
                               '" in the database.', 417)
-    
-    #Normaly there will be only one element with that name
-    ug = query[0]
-    ug.prepare_delete()
-    query.delete()
+ 
+    ug = db.session.query(
+                usergroup.Usergroup).filter(
+                usergroup.Usergroup.name == name)
+    ug[0].prepare_delete()
+    ug.delete()
 
     try:
         db.session.commit()

--- a/passhportd/app/views_mod/usergroup/usergroup.py
+++ b/passhportd/app/views_mod/usergroup/usergroup.py
@@ -201,7 +201,8 @@ def usergroup_delete(name):
     if query is None:
         return utils.response('ERROR: No usergroup with the name "' + name + \
                               '" in the database.', 417)
- 
+
+    #Normaly there will be only one element with that name
     ug = db.session.query(
                 usergroup.Usergroup).filter(
                 usergroup.Usergroup.name == name)


### PR DESCRIPTION
There was an error with API.
When you try to delete an already absent usergroup there was an error 500 instead of 417. This update fix this.