### PR TITLE
Security: bump pyasn1 to 0.6.2 for CVE-2026-23490

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ MarkupSafe==2.1.1
 pbr==5.10.0
 psutil==5.9.2
 psycopg2-binary==2.9.11
-pyasn1==0.4.8
+pyasn1==0.6.2
 pycparser==2.21
 python-dateutil==2.8.2
 python-editor==1.0.4

--- a/tools/install/install_debian_13.sh
+++ b/tools/install/install_debian_13.sh
@@ -76,6 +76,8 @@ create_passhport_user()
   [ ! -e "/home/passhport/" ] && mkdir -p /home/passhport && chown passhport:passhport /home/passhport
   # Needed for Apache WSGI
   chmod o+rx /home/passhport/
+  # Needed for authorized keys
+  ${PASSHPORTDO} 'mkdir ~/.ssh && chmod 700 ~/.ssh'
   echo
 }
 


### PR DESCRIPTION
Update pyasn1 from 0.4.8 to 0.6.2 to fix a DoS vulnerability caused by malformed RELATIVE-OID inputs (memory exhaustion).

Fixes: #666
Ref: CVE-2026-23490