### PR TITLE
feat: add access expiration across relations with watchdog session cu…

### DIFF
--- a/passhport-admin/manager/target.py
+++ b/passhport-admin/manager/target.py
@@ -230,15 +230,20 @@ def prompt_adduser():
     """Prompt user to obtain data to add a user"""
     username = input("Username: ")
     targetname = input("Targetname: ")
+    expires_at = input("Expiration (YYYY-mm-ddTHH:MM:SS, optional): ")
 
     return {"<username>": username,
-            "<targetname>": targetname}
+            "<targetname>": targetname,
+            "--expires-at": expires_at}
 
 
 def adduser(param):
     """Format param to add a user"""
-    return {"username": param["<username>"],
+    data = {"username": param["<username>"],
             "targetname": param["<targetname>"]}
+    if "--expires-at" in param and param["--expires-at"]:
+        data["expires_at"] = param["--expires-at"]
+    return data
 
 
 def prompt_rmuser():
@@ -260,15 +265,20 @@ def prompt_addusergroup():
     """Prompt user to obtain data to add a usergroup"""
     usergroupname = input("Usergroupname: ")
     targetname = input("Targetname: ")
+    expires_at = input("Expiration (YYYY-mm-ddTHH:MM:SS, optional): ")
 
     return {"<usergroupname>": usergroupname,
-            "<targetname>": targetname}
+            "<targetname>": targetname,
+            "--expires-at": expires_at}
 
 
 def addusergroup(param):
     """Format param to add a usergroup"""
-    return {"usergroupname": param["<usergroupname>"],
+    data = {"usergroupname": param["<usergroupname>"],
             "targetname": param["<targetname>"]}
+    if "--expires-at" in param and param["--expires-at"]:
+        data["expires_at"] = param["--expires-at"]
+    return data
 
 
 def prompt_rmusergroup():

--- a/passhport-admin/manager/targetgroup.py
+++ b/passhport-admin/manager/targetgroup.py
@@ -64,15 +64,20 @@ def prompt_adduser():
     """Prompt user to obtain data to add a user"""
     username = input("Username: ")
     targetgroupname = input("Targetgroupname: ")
+    expires_at = input("Expiration (YYYY-mm-ddTHH:MM:SS, optional): ")
 
     return {"<username>": username,
-            "<targetgroupname>": targetgroupname}
+            "<targetgroupname>": targetgroupname,
+            "--expires-at": expires_at}
 
 
 def adduser(param):
     """Format param to add a user"""
-    return {"username": param["<username>"],
+    data = {"username": param["<username>"],
             "targetgroupname": param["<targetgroupname>"]}
+    if "--expires-at" in param and param["--expires-at"]:
+        data["expires_at"] = param["--expires-at"]
+    return data
 
 
 def prompt_rmuser():
@@ -124,15 +129,20 @@ def prompt_addusergroup():
     """Prompt user to obtain data to add a usergroup"""
     usergroupname = input("Usergroupname: ")
     targetgroupname = input("Targetgroupname: ")
+    expires_at = input("Expiration (YYYY-mm-ddTHH:MM:SS, optional): ")
 
     return {"<usergroupname>": usergroupname,
-            "<targetgroupname>": targetgroupname}
+            "<targetgroupname>": targetgroupname,
+            "--expires-at": expires_at}
 
 
 def addusergroup(param):
     """Format param to add a usergroup"""
-    return {"usergroupname": param["<usergroupname>"],
+    data = {"usergroupname": param["<usergroupname>"],
             "targetgroupname": param["<targetgroupname>"]}
+    if "--expires-at" in param and param["--expires-at"]:
+        data["expires_at"] = param["--expires-at"]
+    return data
 
 
 def prompt_rmusergroup():

--- a/passhport-admin/passhport-admin
+++ b/passhport-admin/passhport-admin
@@ -27,9 +27,9 @@ Usage:
 [--newcomment=<comment>] [--newsshoptions=<sshoptions>] [--newport=<port>] \
 [--sessiondur=<sessiondur>]) ]
     passhport-admin target (adduser | rmuser) \
-[(<username> <targetname>)]
+[(<username> <targetname>) [--expires-at=<expiresat>]]
     passhport-admin target (addusergroup | rmusergroup) \
-[(<usergroupname> <targetname>)]
+[(<usergroupname> <targetname>) [--expires-at=<expiresat>]]
     passhport-admin target delete [([-f | --force] <name>)]
     passhport-admin usergroup list
     passhport-admin usergroup search [<pattern>]
@@ -49,11 +49,11 @@ Usage:
     passhport-admin targetgroup edit [(<name> [--newname=<name>] \
 [--newcomment=<comment>])]
     passhport-admin targetgroup (adduser | rmuser) \
-[(<username> <targetgroupname>)]
+[(<username> <targetgroupname>) [--expires-at=<expiresat>]]
     passhport-admin targetgroup (addtarget | rmtarget) \
 [(<targetname> <targetgroupname>)]
     passhport-admin targetgroup (addusergroup | rmusergroup) \
-[(<usergroupname> <targetgroupname>)]
+[(<usergroupname> <targetgroupname>) [--expires-at=<expiresat>]]
     passhport-admin targetgroup (addtargetgroup | rmtargetgroup) \
 [(<subtargetgroupname> <targetgroupname>)]
     passhport-admin targetgroup delete [([-f | --force] <name>)]
@@ -96,6 +96,8 @@ of the target.
     --newport=<port>                Set the new port used \
     --newsessiondur=<sessiondur>    Set the new session duration in minutes for \
 when supported.
+    --expires-at=<expiresat>        Set access expiration (local time, \
+YYYY-mm-ddTHH:MM:SS or partial).
 
 with the target.
 """

--- a/passhport/connections_utils/ssh.py
+++ b/passhport/connections_utils/ssh.py
@@ -9,14 +9,15 @@ from __future__ import unicode_literals
 import os, requests, shlex, sys
 
 def connect(target, filelog, login, port, sshoptions, pid, url_passhport, 
-            cert, ssh_script, username, targetname, originalcmd):
+            cert, ssh_script, username, targetname, originalcmd, expires_at):
     """ Simply launch the ssh connection or execute the ssh command"""
     if not originalcmd:
         # We replace this process by the connexion to free some memory
         os.execl("/bin/bash", " ",
                  ssh_script,
                  filelog, str(port), login, target, str(pid),
-                 url_passhport, cert, username, targetname, sshoptions)
+                 url_passhport, cert, username, targetname, expires_at,
+                 sshoptions)
 
     else:
         ssh_args = [

--- a/passhport/passhport
+++ b/passhport/passhport
@@ -112,6 +112,14 @@ def checkandconnect(indexed_target_list, choice, username, originalcmd,
     target     = target_found[2]
     login      = get(url_passhport + "target" + "/login/" + \
                  targetname)
+    expires_at = get(url_passhport + "user/access_expiration/" + \
+                 username + "/" + targetname)
+    if isinstance(expires_at, str):
+        expires_at = expires_at.strip()
+    if expires_at == 1 or str(expires_at).startswith("ERROR"):
+        expires_at = ""
+    if expires_at == "unlimited":
+        expires_at = ""
     # If target login is set at $email => 
     # we user login=username (without @...)
     if login == "$email":
@@ -169,7 +177,8 @@ def checkandconnect(indexed_target_list, choice, username, originalcmd,
             cert = SSL_CERTIFICAT
         # Standard SSH connection
         ssh.connect(target, filelog, login, port, sshoptions, pid,
-                    url_passhport, cert, SSH_SCRIPT, username, targetname, originalcmd)
+                    url_passhport, cert, SSH_SCRIPT, username, targetname,
+                    originalcmd, expires_at)
 
     return True
 
@@ -370,6 +379,15 @@ if __name__ == '__main__':
 
     #Construct the indexted targets list
     indexed_target_list = build_targets_list(target_list)
+
+    # Notify the user if the previous session ended by expiration.
+    expired_notice = "/tmp/passhport-expired-" + username
+    if os.path.isfile(expired_notice):
+        with open(expired_notice, "r") as f:
+            message = f.read().strip()
+            if message:
+                print(message)
+        os.remove(expired_notice)
 
     # Check if it's interactive ssh or another type of connection:
     if originalcmd or passhport_target:

--- a/passhport/passhport-connect.sh
+++ b/passhport/passhport-connect.sh
@@ -12,6 +12,8 @@ CERT=$7
 OPTION="$@"
 USERNAME="$8"
 TARGETNAME="$9"
+EXPIRES_AT="${10}"
+export EXPIRES_AT
 OPTIONS=""
 KEEPCONNECT="$(grep '^KEEPCONNECT[[:space:]]=[[:space:]]True$' /etc/passhport/passhport.ini | wc -l)"
 PASSHHOMEDIR="/home/passhport"
@@ -23,17 +25,69 @@ PASSHPORTBIN="${PASSHHOMEDIR}/passhport/passhport/passhport"
 ###### We trap a manual window close to let the script to end ######
 trap "echo 'You are not allowed to stop disconnection. Consider Ctrl-D.'" SIGHUP SIGINT SIGKILL SIGTERM SIGSTOP
 
-#Remove 7 first arguments and put the others in the OPTIONS variable
+#Remove 10 first arguments and put the others in the OPTIONS variable
 i=0
 for option in ${OPTION}
 do
-    if [ "$i" -lt "9" ]
+    if [ "$i" -lt "10" ]
     then
         i=$(($i +1))
     else
         OPTIONS="${OPTIONS} ${option}"
     fi
 done
+
+EXPIRED_NOTICE="/tmp/passhport-expired-${USERNAME}"
+if [ -n "${EXPIRES_AT}" ] && [ "${EXPIRES_AT}" != "unlimited" ]
+then
+    # Compute the remaining seconds before expiration in local time.
+    REMAIN="$(${PYTHONBIN} - <<'PY'
+import os
+from datetime import datetime
+
+expires_at = os.environ.get("EXPIRES_AT")
+try:
+    exp = datetime.strptime(expires_at, "%Y-%m-%dT%H:%M:%S")
+    now = datetime.now()
+    delta = int((exp - now).total_seconds())
+    if delta < 0:
+        delta = 0
+    print(delta)
+except Exception:
+    print(0)
+PY
+)"
+
+    if [ "${REMAIN}" -gt 0 ]
+    then
+        ( sleep "${REMAIN}";
+          # Mark expiration for the next prompt.
+          echo "Session expired for ${TARGETNAME} at ${EXPIRES_AT}." > "${EXPIRED_NOTICE}";
+          # Kill the local session first (passhportd may be remote).
+          kill -TERM -"${PID}" 2>/dev/null
+          sleep 2
+          kill -KILL -"${PID}" 2>/dev/null
+          # Log the end of session in passhportd.
+          if [ "${CERT}" == "/dev/null" ]
+          then
+              wget -qO - ${URL}connection/ssh/disconnect/${PID} &> /dev/null
+          else
+              wget --ca-certificate=${CERT} -qO - ${URL}connection/ssh/disconnect/${PID} &> /dev/null
+          fi
+        ) &
+    else
+        echo "Session expired for ${TARGETNAME} at ${EXPIRES_AT}." > "${EXPIRED_NOTICE}"
+        kill -TERM -"${PID}" 2>/dev/null
+        sleep 2
+        kill -KILL -"${PID}" 2>/dev/null
+        if [ "${CERT}" == "/dev/null" ]
+        then
+            wget -qO - ${URL}connection/ssh/disconnect/${PID} &> /dev/null
+        else
+            wget --ca-certificate=${CERT} -qO - ${URL}connection/ssh/disconnect/${PID} &> /dev/null
+        fi
+    fi
+fi
 
 ###### SSH CONNECTION ########
 script -q --timing=${FILELOG}.timing ${FILELOG} -c "ssh -t -p ${PORT} ${LOGIN}@${TARGET} ${OPTIONS}"

--- a/passhportd/app/models.py
+++ b/passhportd/app/models.py
@@ -84,6 +84,7 @@ class Target_User(db.Model):
         db.Integer,
         db.ForeignKey("user.id"),
         primary_key=True)
+    expires_at = db.Column(db.DateTime, index=True, nullable=True)
 
 
 class Tg_admins(db.Model):
@@ -136,6 +137,7 @@ class Target_Group(db.Model):
         db.Integer,
         db.ForeignKey("usergroup.id"),
         primary_key=True)
+    expires_at = db.Column(db.DateTime, index=True, nullable=True)
 
 
 class TGroup_User(db.Model):
@@ -149,6 +151,7 @@ class TGroup_User(db.Model):
         db.Integer,
         db.ForeignKey("user.id"),
         primary_key=True)
+    expires_at = db.Column(db.DateTime, index=True, nullable=True)
 
 
 class TGroup_Target(db.Model):
@@ -175,3 +178,4 @@ class Tgroup_Group(db.Model):
         db.Integer,
         db.ForeignKey("usergroup.id"),
         primary_key=True)
+    expires_at = db.Column(db.DateTime, index=True, nullable=True)

--- a/passhportd/app/models_mod/target.py
+++ b/passhportd/app/models_mod/target.py
@@ -2,7 +2,8 @@
 import random, os, config
 from datetime import datetime, timedelta, date
 from app import app, db
-from app.models_mod import targetgroup, passentry
+from app.models_mod import targetgroup, passentry, user, usergroup
+from app.models import Target_User, Target_Group
 from flask import jsonify
 from subprocess import Popen, PIPE
 
@@ -74,8 +75,10 @@ class Target(db.Model):
             output.append("Session duration: {}".format(str(timedelta(
                         minutes= self.show_sessionduration()))[:-6] + "h"))
         output.append("Comment: {}".format(self.comment))
-        output.append("Attached users: " + " ".join(self.username_list()))
-        output.append("Usergroup list: " + " ".join(self.usergroupname_list()))
+        output.append("Attached users: " + \
+                      " ".join(self.username_list_with_expiration()))
+        output.append("Usergroup list: " + \
+                      " ".join(self.usergroupname_list_with_expiration()))
 
         output.append("Users who can access this target: " + \
                       " ".join(self.list_all_usernames()))
@@ -269,6 +272,24 @@ class Target(db.Model):
             usernames.append(user.show_name())
 
         return usernames
+
+
+    def username_list_with_expiration(self):
+        """Return direct users with expiration when set"""
+        entries = []
+        assoc = db.session.query(Target_User).filter(
+            Target_User.target_id == self.id).all()
+        for row in assoc:
+            user_obj = db.session.query(user.User).filter(
+                user.User.id == row.user_id).first()
+            if not user_obj:
+                continue
+            if row.expires_at:
+                expires_at = row.expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+                entries.append(user_obj.show_name() + " (" + expires_at + ")")
+            else:
+                entries.append(user_obj.show_name())
+        return entries
     
 
     def username_list_json(self):
@@ -342,6 +363,24 @@ class Target(db.Model):
             usergroupnames.append(usergroup.show_name())
 
         return usergroupnames
+
+
+    def usergroupname_list_with_expiration(self):
+        """Return direct usergroups with expiration when set"""
+        entries = []
+        assoc = db.session.query(Target_Group).filter(
+            Target_Group.target_id == self.id).all()
+        for row in assoc:
+            ug = db.session.query(usergroup.Usergroup).filter(
+                usergroup.Usergroup.id == row.group_id).first()
+            if not ug:
+                continue
+            if row.expires_at:
+                expires_at = row.expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+                entries.append(ug.show_name() + " (" + expires_at + ")")
+            else:
+                entries.append(ug.show_name())
+        return entries
 
 
     def usergroupname_list_json(self):

--- a/passhportd/app/models_mod/targetgroup.py
+++ b/passhportd/app/models_mod/targetgroup.py
@@ -1,5 +1,7 @@
 # -*-coding:Utf-8 -*-
 from app import db, models_mod
+from app.models import TGroup_User, Tgroup_Group
+from app.models_mod import user, usergroup
 
 # Table to handle the self-referencing many-to-many relationship
 # for the Targetgroup class:
@@ -60,11 +62,11 @@ class Targetgroup(db.Model):
         output.append("Name: {}".format(self.name))
         output.append("Comment: {}".format(self.comment))
         output.append("User list: " + \
-                      " ".join(self.username_list()))
+                      " ".join(self.username_list_with_expiration()))
         output.append("Target list: " + \
                       " ".join(self.targetname_list()))
         output.append("Usergroup list: " + \
-                      " ".join(self.usergroupname_list()))
+                      " ".join(self.usergroupname_list_with_expiration()))
         output.append("Targetgroup list: " + \
                       " ".join(self.targetgroupname_list()))
 
@@ -161,6 +163,24 @@ class Targetgroup(db.Model):
             usernames.append(user.show_name())
 
         return usernames
+
+
+    def username_list_with_expiration(self):
+        """Return direct users with expiration when set"""
+        entries = []
+        assoc = db.session.query(TGroup_User).filter(
+            TGroup_User.targetgroup_id == self.id).all()
+        for row in assoc:
+            user_obj = db.session.query(user.User).filter(
+                user.User.id == row.user_id).first()
+            if not user_obj:
+                continue
+            if row.expires_at:
+                expires_at = row.expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+                entries.append(user_obj.show_name() + " (" + expires_at + ")")
+            else:
+                entries.append(user_obj.show_name())
+        return entries
 
 
     def all_username_list(self, parsed_usergroups = None):
@@ -352,6 +372,24 @@ class Targetgroup(db.Model):
             usergroupnames.append(usergroup.show_name())
 
         return usergroupnames
+
+
+    def usergroupname_list_with_expiration(self):
+        """Return direct usergroups with expiration when set"""
+        entries = []
+        assoc = db.session.query(Tgroup_Group).filter(
+            Tgroup_Group.targetgroup_id == self.id).all()
+        for row in assoc:
+            ug = db.session.query(usergroup.Usergroup).filter(
+                usergroup.Usergroup.id == row.group_id).first()
+            if not ug:
+                continue
+            if row.expires_at:
+                expires_at = row.expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+                entries.append(ug.show_name() + " (" + expires_at + ")")
+            else:
+                entries.append(ug.show_name())
+        return entries
 
 
     def usergroup_list(self):

--- a/passhportd/app/models_mod/user.py
+++ b/passhportd/app/models_mod/user.py
@@ -12,6 +12,7 @@ from app import db
 from app.models_mod import target
 from app.models_mod import usergroup
 from app.models_mod import targetgroup
+from app.models import Target_User, Target_Group, TGroup_User, Tgroup_Group
    
 class User(db.Model):
     """User defines information for every adminsys using passhport"""
@@ -143,43 +144,98 @@ class User(db.Model):
 
     def accessible_target_list(self, style="object"):
         """Return targets accessible to the users (as object or names list)"""
-        targets = []
-        output = "Accessible directly: "
+        access_map = self.accessible_target_map()
+        targets = [entry["target"] for entry in access_map.values()]
 
-        # 1. list all the directly attached targets
-        for target in self.targets:
-            targets.append(target)
-            output = output + target.show_name() + " ; "
-        
-        output = output + "\nAccessible through usergroups: "
-        # 2. list all the targets accessible through usergroup
-        for usergroup in self.usergroups:
-            output = output + "\n" + usergroup.show_name() + ": "
-            for target in usergroup.accessible_target_list(mode="obj"):
-                output = output + target.show_name() + " ; "
-                if target not in targets:
-                    targets.append(target)
-
-        output = output + "\nAccessible through targetgroups: "
-        # 3. list all the targets accessible through targetgroup
-        for targetgroup in self.targetgroups:
-            output = output + "\n" + targetgroup.show_name() + ": "
-            for target in targetgroup.accessible_target_list():
-                output = output + target.show_name() + " ; "
-                if target not in targets:
-                    targets.append(target)
-
-
-        # return target objects or names depending of style
+        # Format depending on the requested style.
         if style == "names":
             targetnames = []
-            for target in targets:
-                targetnames.append(target.show_name())
-            targets = sorted(targetnames)
-        elif style == "details":
-            targets = output
-        
+            for t in targets:
+                targetnames.append(t.show_name())
+            return sorted(targetnames)
+        if style == "details":
+            lines = []
+            for entry in sorted(access_map.values(),
+                                key=lambda e: e["target"].show_name()):
+                # Show the effective expiration when applicable.
+                expires_at = entry["expires_at"]
+                if expires_at:
+                    expires_at = expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+                    lines.append(entry["target"].show_name() + \
+                                 " (expires at " + expires_at + ")")
+                else:
+                    lines.append(entry["target"].show_name())
+            return "\n".join(lines)
+
         return targets
+
+
+    def accessible_target_map(self):
+        """Return a map of accessible targets with effective expirations."""
+        now = datetime.now()
+        access_map = {}
+
+        def merge_access(target_obj, expires_at):
+            # Merge multiple access paths: keep the latest expiration,
+            # and treat any "no expiration" as unlimited.
+            current = access_map.get(target_obj.id)
+            if current is None:
+                access_map[target_obj.id] = {
+                    "target": target_obj,
+                    "expires_at": expires_at
+                }
+                return
+            if current["expires_at"] is None:
+                return
+            if expires_at is None:
+                current["expires_at"] = None
+                return
+            if expires_at > current["expires_at"]:
+                current["expires_at"] = expires_at
+
+        # Direct access: user -> target.
+        direct_query = db.session.query(Target_User, target.Target).join(
+            target.Target, Target_User.target_id == target.Target.id
+        ).filter(Target_User.user_id == self.id)
+        for entry, t in direct_query:
+            if entry.expires_at and entry.expires_at < now:
+                continue
+            merge_access(t, entry.expires_at)
+
+        # Access via usergroups: usergroup -> target.
+        for ug in self.usergroups:
+            group_query = db.session.query(Target_Group, target.Target).join(
+                target.Target, Target_Group.target_id == target.Target.id
+            ).filter(Target_Group.group_id == ug.id)
+            for entry, t in group_query:
+                if entry.expires_at and entry.expires_at < now:
+                    continue
+                merge_access(t, entry.expires_at)
+
+        # Access via targetgroups directly attached to the user.
+        tg_query = db.session.query(TGroup_User, targetgroup.Targetgroup).join(
+            targetgroup.Targetgroup,
+            TGroup_User.targetgroup_id == targetgroup.Targetgroup.id
+        ).filter(TGroup_User.user_id == self.id)
+        for entry, tg in tg_query:
+            if entry.expires_at and entry.expires_at < now:
+                continue
+            for t in tg.accessible_target_list():
+                merge_access(t, entry.expires_at)
+
+        # Access via usergroups that grant targetgroups.
+        for ug in self.usergroups:
+            tgg_query = db.session.query(Tgroup_Group, targetgroup.Targetgroup).join(
+                targetgroup.Targetgroup,
+                Tgroup_Group.targetgroup_id == targetgroup.Targetgroup.id
+            ).filter(Tgroup_Group.group_id == ug.id)
+            for entry, tg in tgg_query:
+                if entry.expires_at and entry.expires_at < now:
+                    continue
+                for t in tg.accessible_target_list():
+                    merge_access(t, entry.expires_at)
+
+        return access_map
 
 
     def direct_targets(self):

--- a/passhportd/app/views_mod/target/target.py
+++ b/passhportd/app/views_mod/target/target.py
@@ -5,6 +5,7 @@ from sqlalchemy import exc, and_
 from sqlalchemy.orm import sessionmaker
 from app import app, db
 from app.models_mod import user, target, usergroup, exttargetaccess, passentry
+from app.models import Target_User, Target_Group
 from . import api
 from subprocess import Popen, PIPE
 from datetime import datetime, timedelta
@@ -431,8 +432,21 @@ def target_adduser():
         return utils.response('ERROR: no target "' + targetname + \
                               '" in the database ', 417)
 
-    # Now we can add the user
-    t.adduser(u)
+    expires_raw = request.form.get("expires_at")
+    expires_at = utils.parse_expiration(expires_raw)
+    if expires_at is False:
+        return utils.response('ERROR: Bad expiration date format', 417)
+
+    # Add or update the relation with an optional expiration.
+    assoc = db.session.query(Target_User).filter_by(
+        user_id=u.id, target_id=t.id).first()
+    if assoc:
+        if "expires_at" in request.form:
+            assoc.expires_at = expires_at
+    else:
+        assoc = Target_User(user_id=u.id, target_id=t.id,
+                            expires_at=expires_at)
+        db.session.add(assoc)
     try:
         db.session.commit()
     except exc.SQLAlchemyError as e:
@@ -519,8 +533,21 @@ def target_addusergroup():
         return utils.response('ERROR: no target "' + targetname + \
                               '" in the database ', 417)
 
-    # Now we can add the user
-    t.addusergroup(ug)
+    expires_raw = request.form.get("expires_at")
+    expires_at = utils.parse_expiration(expires_raw)
+    if expires_at is False:
+        return utils.response('ERROR: Bad expiration date format', 417)
+
+    # Add or update the relation with an optional expiration.
+    assoc = db.session.query(Target_Group).filter_by(
+        group_id=ug.id, target_id=t.id).first()
+    if assoc:
+        if "expires_at" in request.form:
+            assoc.expires_at = expires_at
+    else:
+        assoc = Target_Group(group_id=ug.id, target_id=t.id,
+                             expires_at=expires_at)
+        db.session.add(assoc)
     try:
         db.session.commit()
     except exc.SQLAlchemyError as e:

--- a/passhportd/app/views_mod/targetgroup/targetgroup.py
+++ b/passhportd/app/views_mod/targetgroup/targetgroup.py
@@ -5,6 +5,7 @@ from sqlalchemy import exc
 from sqlalchemy.orm import sessionmaker
 from app import app, db
 from app.models_mod import user, target, usergroup, targetgroup
+from app.models import TGroup_User, Tgroup_Group
 from . import api
 
 from .. import utilities as utils
@@ -229,8 +230,21 @@ def targetgroup_adduser():
         return utils.response('ERROR: no targetgroup "' + targetgroupname + \
                               '" in the database ', 417)
 
-    # Now we can add the user
-    tg.adduser(u)
+    expires_raw = request.form.get("expires_at")
+    expires_at = utils.parse_expiration(expires_raw)
+    if expires_at is False:
+        return utils.response('ERROR: Bad expiration date format', 417)
+
+    # Add or update the relation with an optional expiration.
+    assoc = db.session.query(TGroup_User).filter_by(
+        user_id=u.id, targetgroup_id=tg.id).first()
+    if assoc:
+        if "expires_at" in request.form:
+            assoc.expires_at = expires_at
+    else:
+        assoc = TGroup_User(user_id=u.id, targetgroup_id=tg.id,
+                            expires_at=expires_at)
+        db.session.add(assoc)
     try:
         db.session.commit()
     except exc.SQLAlchemyError as e:
@@ -411,8 +425,21 @@ def targetgroup_addusergroup():
         return utils.response('ERROR: no targetgroup "' + targetgroupname + \
                               '" in the database ', 417)
 
-    # Now we can add the usergroup
-    tg.addusergroup(ug)
+    expires_raw = request.form.get("expires_at")
+    expires_at = utils.parse_expiration(expires_raw)
+    if expires_at is False:
+        return utils.response('ERROR: Bad expiration date format', 417)
+
+    # Add or update the relation with an optional expiration.
+    assoc = db.session.query(Tgroup_Group).filter_by(
+        group_id=ug.id, targetgroup_id=tg.id).first()
+    if assoc:
+        if "expires_at" in request.form:
+            assoc.expires_at = expires_at
+    else:
+        assoc = Tgroup_Group(group_id=ug.id, targetgroup_id=tg.id,
+                             expires_at=expires_at)
+        db.session.add(assoc)
     try:
         db.session.commit()
     except exc.SQLAlchemyError as e:

--- a/passhportd/app/views_mod/user/user.py
+++ b/passhportd/app/views_mod/user/user.py
@@ -200,7 +200,8 @@ def uaccessible_targets(name, withid = True, returnlist = False):
         return utils.response('ERROR: No user with the name "' + name + \
                               '" in the database.', 417)
 
-    target_list = user_data.accessible_target_list()
+    access_map = user_data.accessible_target_map()
+    target_list = [entry["target"] for entry in access_map.values()]
     formatted_target_list = []
 
     for each_target in target_list:
@@ -212,6 +213,10 @@ def uaccessible_targets(name, withid = True, returnlist = False):
             data = data + each_target.show_name() + " " + \
                    each_target.show_hostname() + " " + \
                    each_target.show_comment()
+            expires_at = access_map.get(each_target.id, {}).get("expires_at")
+            if expires_at:
+                data = data + " [expires " + \
+                       expires_at.strftime("%Y-%m-%dT%H:%M:%S") + "]"
             formatted_target_list.append(data)
     if returnlist:
         return [target.show_name() for target in target_list 
@@ -220,6 +225,29 @@ def uaccessible_targets(name, withid = True, returnlist = False):
         # We need to be sorted by target ID. Not so easy cause ID are strings
         formatted_target_list.sort(key=naturalkeys) #naturalkey is a method right above
     return utils.response("\n".join(formatted_target_list), 200)
+
+
+@app.route("/user/access_expiration/<username>/<targetname>")
+def user_access_expiration(username, targetname):
+    """Return the effective expiration for this user/target access"""
+    # Check for required fields
+    if not username or not targetname:
+        return utils.response("ERROR: Username or targetname is missing ", 417)
+
+    user_data = user.User.query.filter_by(name=username).first()
+    if user_data is None:
+        return utils.response('ERROR: No user with the name "' + \
+                              username + '" in the database.', 417)
+
+    access_map = user_data.accessible_target_map()
+    for entry in access_map.values():
+        if entry["target"].show_name() == targetname:
+            if entry["expires_at"] is None:
+                return utils.response("unlimited", 200)
+            return utils.response(
+                entry["expires_at"].strftime("%Y-%m-%dT%H:%M:%S"), 200)
+
+    return utils.response("ERROR: No access to target", 417)
 
 
 @app.route("/user/accessible_targets/<name>")

--- a/passhportd/app/views_mod/utilities.py
+++ b/passhportd/app/views_mod/utilities.py
@@ -6,6 +6,7 @@ import stat
 import smtplib
 
 from io import open
+from datetime import datetime
 from sshpubkeys import SSHKey
 
 from app import app, db
@@ -191,6 +192,42 @@ def is_number(s):
     try:
         float(s)
         return True
+    except ValueError:
+        return False
+
+
+def parse_expiration(value):
+    """Parse a local datetime string with optional parts."""
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    if value.lower() in ["none", "null", "unlimited"]:
+        return None
+
+    if "T" in value:
+        date_part, time_part = value.split("T", 1)
+    else:
+        date_part, time_part = value, ""
+
+    date_fields = date_part.split("-")
+    if len(date_fields) > 3 or len(date_fields) < 1:
+        return False
+
+    try:
+        year = int(date_fields[0])
+        month = int(date_fields[1]) if len(date_fields) >= 2 and date_fields[1] else 1
+        day = int(date_fields[2]) if len(date_fields) >= 3 and date_fields[2] else 1
+        hour = minute = second = 0
+        if time_part:
+            time_fields = time_part.split(":")
+            if len(time_fields) > 3:
+                return False
+            hour = int(time_fields[0]) if len(time_fields) >= 1 and time_fields[0] else 0
+            minute = int(time_fields[1]) if len(time_fields) >= 2 and time_fields[1] else 0
+            second = int(time_fields[2]) if len(time_fields) >= 3 and time_fields[2] else 0
+        return datetime(year, month, day, hour, minute, second)
     except ValueError:
         return False
 

--- a/passhportd/migrations/versions/b9f2e6c9d1a3_add_access_expiration.py
+++ b/passhportd/migrations/versions/b9f2e6c9d1a3_add_access_expiration.py
@@ -1,0 +1,37 @@
+"""add access expiration
+
+Revision ID: b9f2e6c9d1a3
+Revises: 13746bb16d7b
+Create Date: 2025-01-21 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b9f2e6c9d1a3'
+down_revision = '13746bb16d7b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('target_user', sa.Column('expires_at', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_target_user_expires_at'), 'target_user', ['expires_at'], unique=False)
+    op.add_column('target_group', sa.Column('expires_at', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_target_group_expires_at'), 'target_group', ['expires_at'], unique=False)
+    op.add_column('tgroup_user', sa.Column('expires_at', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_tgroup_user_expires_at'), 'tgroup_user', ['expires_at'], unique=False)
+    op.add_column('tgroup_group', sa.Column('expires_at', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_tgroup_group_expires_at'), 'tgroup_group', ['expires_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_tgroup_group_expires_at'), table_name='tgroup_group')
+    op.drop_column('tgroup_group', 'expires_at')
+    op.drop_index(op.f('ix_tgroup_user_expires_at'), table_name='tgroup_user')
+    op.drop_column('tgroup_user', 'expires_at')
+    op.drop_index(op.f('ix_target_group_expires_at'), table_name='target_group')
+    op.drop_column('target_group', 'expires_at')
+    op.drop_index(op.f('ix_target_user_expires_at'), table_name='target_user')
+    op.drop_column('target_user', 'expires_at')


### PR DESCRIPTION
…toff

Add expires_at DateTime fields on access relation tables (target_user, target_group, tgroup_user, tgroup_group) and include Alembic migration.

Implement local-time expiration parsing with partial ISO-like inputs (year/month/day/time), and compute effective access per user by merging all access paths (direct, via usergroups, via targetgroups). Effective expiration is the latest valid date unless any path is unlimited.

Expose expiration in passhportd: include it in accessible target lists, provide user/access_expiration endpoint, and show expiration details for targets and targetgroups.

Extend passhport-admin CLI and prompts to accept --expires-at for adduser/addusergroup on targets and targetgroups, and forward it to the API.

Update passhport and connection utils to request expiration, display it in the targets list, and pass it into the connection script.

Add watchdog in passhport-connect.sh to terminate the local process group at expiration and notify passhportd; store a one-time notice so the user sees a detailed expiration message when returning to the passhport prompt.