### PR TITLE
Prepare the `v3.0.1` patch release with security-focused dependency updates and a small CLI help text fix.

### DIFF
--- a/passhport-admin/passhport-admin
+++ b/passhport-admin/passhport-admin
@@ -93,7 +93,7 @@ when supported.
     --newlogin=<login>              Set the new login of the target.
     --newsshoptions=<sshoptions>    Set the new SSH options \
 of the target.
-    --newport=<port>                Set the new port used \
+    --newport=<port>                Set the new port used
     --newsessiondur=<sessiondur>    Set the new session duration in minutes for \
 when supported.
     --expires-at=<expiresat>        Set access expiration (local time, \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==2.0.0
 chardet==5.0.0
 charset-normalizer==2.1.1
 click==8.1.3
-cryptography==46.0.3
+cryptography==46.0.7
 decorator==5.1.1
 docopt==0.6.2
 Flask==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ importlib-metadata==4.12.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 ldap3==2.9.1
-Mako==1.2.2
+Mako==1.3.11
 MarkupSafe==2.1.1
 pbr==5.10.0
 psutil==5.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ tabulate==0.9.0
 Tempita==0.5.2
 legacy-cgi==2.6.2
 urllib3==2.6.3
-wheel==0.38.4
+wheel==0.46.2
 Werkzeug==3.1.5
 zipp==3.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ MarkupSafe==2.1.1
 pbr==5.10.0
 psutil==5.9.2
 psycopg2-binary==2.9.11
-pyasn1==0.6.2
+pyasn1==0.6.3
 pycparser==2.21
 python-dateutil==2.8.2
 python-editor==1.0.4


### PR DESCRIPTION
- Bump `cryptography` from `46.0.3` to `46.0.7`
- Bump `Mako` from `1.2.2` to `1.3.11`
- Bump `pyasn1` from `0.6.2` to `0.6.3`
- Bump `wheel` from `0.38.4` to `0.46.2`
- Fix a formatting issue in the `passhport-admin` help output for `--newport/--newsessiondur`
